### PR TITLE
Fix: Run coding standard job on PHP 7.3 only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
             matrix:
                 php-version:
                     - "7.3"
-                    - "7.4"
 
         steps:
             - name: "Checkout"


### PR DESCRIPTION
This PR

* [x] runs the coding standard job on PHP 7.3 only